### PR TITLE
Add a note about VS Code setting no longer being required

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
+	// This setting is unnecessary when using >= v3.88.1
+	// (or v3.89.20240513 for pre-release versions) of the
+	// Dart extension.
 	"dart.experimentalMacroSupport": true,
 }

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ You can also run/debug from your IDE using the instructions below.
 
 ## VS Code
 
-You will need to set the `"dart.experimentalMacroSupport": true,` option in your
-VS Code settings (it's already set in `.vscode/settings.json` for this project).
+If you are using a version of the Dart extension for VS Code prior to v3.88.1
+(or v3.39.20240513 if using pre-releases), you will need to set the
+`"dart.experimentalMacroSupport": true,` option in your VS Code settings (it's
+already set in `.vscode/settings.json` for this project).
 
 To run/debug from VS Code, you will need to add `"--enable-experiment=macros"`
 to `toolArgs` in your `.vscode/launch.json` (it's already done for this


### PR DESCRIPTION
As of todays updates to the Dart extension, this setting isn't necessary. I left it in with a note for now (since I don't know how quickly people will update), but it could probably be dropped in the near future to simplify things a little.

(Removing this setting avoids the case where macros are enabled in the analysis_options, but the IDE support isn't enabled so things like Go-to-Definition appear broken).